### PR TITLE
Add energy sensors

### DIFF
--- a/custom_components/iotawatt/__init__.py
+++ b/custom_components/iotawatt/__init__.py
@@ -7,9 +7,10 @@ from httpx import AsyncClient
 from iotawattpy.iotawatt import Iotawatt
 import voluptuous as vol
 
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
 from homeassistant.const import CONF_SCAN_INTERVAL
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady, PlatformNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import (
@@ -118,7 +119,7 @@ class IotawattUpdater(DataUpdateCoordinator):
 
         return sensors
 
-class IotaWattEntity(CoordinatorEntity):
+class IotaWattEntity(CoordinatorEntity, SensorEntity):
     """Defines the base IoTaWatt Energy Device entity."""
 
     def __init__(self, coordinator: IotawattUpdater, entity, mac_address, name):

--- a/custom_components/iotawatt/manifest.json
+++ b/custom_components/iotawatt/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/iotawatt",
   "issue_tracker": "https://github.com/gtdiehl/iotawatt_ha",
   "requirements": [
-    "iotawattpy==0.0.5"
+    "iotawattpy==0.0.6"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/iotawatt/sensor.py
+++ b/custom_components/iotawatt/sensor.py
@@ -89,7 +89,7 @@ class IotaWattSensor(IotaWattEntity):
         if unit == "Watts":
             self._attr_unit_of_measurement = POWER_WATT
             self._attr_device_class = DEVICE_CLASS_POWER
-        if unit == "WattHours":
+        elif unit == "WattHours":
             self._attr_unit_of_measurement = ENERGY_WATT_HOUR
             self._attr_device_class = DEVICE_CLASS_ENERGY
         elif unit == "Volts":

--- a/custom_components/iotawatt/sensor.py
+++ b/custom_components/iotawatt/sensor.py
@@ -112,8 +112,6 @@ class IotaWattSensor(IotaWattEntity):
                 "channel": channel
             }
 
-        if last_reset := self.last_reset:
-            attrs["last_reset"] = last_reset.isoformat()
         return attrs
 
     @property


### PR DESCRIPTION
The upcoming Energy dashboard in Home Assistant needs energy sensors to work. This adds support for the energy type sensors (unit watt-hours) and makes sure all requirements are met so the entities can be used by the Energy dashboard.

Related to: https://github.com/gtdiehl/iotawattpy/pull/3