### PR TITLE
Remove ELECTRIC_POTENTIAL_VOLT constant

### DIFF
--- a/custom_components/iotawatt/sensor.py
+++ b/custom_components/iotawatt/sensor.py
@@ -5,7 +5,6 @@ import logging
 
 from homeassistant.const import (
     POWER_WATT,
-    ELECTRIC_POTENTIAL_VOLT,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_VOLTAGE
 )
@@ -82,7 +81,7 @@ class IotaWattSensor(IotaWattEntity):
             self._attr_unit_of_measurement = POWER_WATT
             self._attr_device_class = DEVICE_CLASS_POWER
         elif unit == "Volts":
-            self._attr_unit_of_measurement = ELECTRIC_POTENTIAL_VOLT
+            self._attr_unit_of_measurement = "V"
             self._attr_device_class = DEVICE_CLASS_VOLTAGE
         else:
             self._attr_unit_of_measurement = unit


### PR DESCRIPTION
The ```ELECTRIC_POTENTIAL_VOLT``` constant can only be used for ```HA 2021.8``` and above. Need to support older versions for now.

Since this integration is not tied to a specific version of HA, we will need to support older versions. Once this code is moved to the official HA repo then we can use the ```ELECTRIC_POTENTIAL_VOLT``` constant