### PR TITLE
Ensure a sensors is updated after each read.

### DIFF
--- a/custom_components/iotawatt/sensor.py
+++ b/custom_components/iotawatt/sensor.py
@@ -69,6 +69,7 @@ class IotaWattSensor(IotaWattEntity):
         self._io_type = sensor.getType()
         self._state = None
         self._attr_state_class = STATE_CLASS_MEASUREMENT
+        self._attr_force_update = True
 
         unit = sensor.getUnit()
         if unit == "Watts":


### PR DESCRIPTION
The energy sensors based on an output (ending with _wh) may not contain the correct result due to how the iotawatt is calculating them (such as a typical Import and Export energy rule).
It may be required to use the `integration` integration to calculate the energy the power device used over a given amount of time.
For the integration to rule, the sensor state must be updated frequently.
The Home Assistant value is to only update the value of a sensor if a change occurred which isn't what we want.

So we configure the HA DataUpdateCoordinator for forced updates.

Fixes #15