### PR TITLE
Update for Home Assistant 2021.9

### DIFF
--- a/custom_components/iotawatt/manifest.json
+++ b/custom_components/iotawatt/manifest.json
@@ -7,10 +7,6 @@
   "requirements": [
     "iotawattpy==0.1.0"
   ],
-  "ssdp": [],
-  "zeroconf": [],
-  "homekit": {},
-  "dependencies": [],
   "codeowners": [
     "@gtdiehl"
   ],

--- a/custom_components/iotawatt/translations/it.json
+++ b/custom_components/iotawatt/translations/it.json
@@ -1,0 +1,23 @@
+{
+    "config": {
+        "error": {
+            "cannot_connect": "Impossibile connettersi",
+            "invalid_auth": "Autenticazione non valida",
+            "unknown": "Errore imprevisto"
+        },
+        "step": {
+            "auth": {
+                "data": {
+                    "password": "Password",
+                    "username": "Nome utente"
+                },
+                "description": "Il dispositivo IoTawatt richiede l'autenticazione. Inserisci il nome utente e la password e fai clic sul pulsante Invia."
+            },
+            "user": {
+                "data": {
+                    "host": "Host"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/iotawatt/translations/no.json
+++ b/custom_components/iotawatt/translations/no.json
@@ -1,0 +1,23 @@
+{
+    "config": {
+        "error": {
+            "cannot_connect": "Tilkobling mislyktes",
+            "invalid_auth": "Ugyldig godkjenning",
+            "unknown": "Uventet feil"
+        },
+        "step": {
+            "auth": {
+                "data": {
+                    "password": "Passord",
+                    "username": "Brukernavn"
+                },
+                "description": "IoTawatt -enheten krever autentisering. Skriv inn brukernavn og passord og klikk p\u00e5 Send -knappen."
+            },
+            "user": {
+                "data": {
+                    "host": "Vert"
+                }
+            }
+        }
+    }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,6 @@
     "name": "IoTaWatt",
     "render_readme": true,
     "domains": ["sensor"],
-    "homeassistant": "2021.8.0",
+    "homeassistant": "2021.9.0",
     "iot_class": ["Local Polling"]
 }


### PR DESCRIPTION
Identical functionality as the one for version 2021.8.

Some key differences with HA iotawatt others than support for high resolution energy sensors: all energy sensors are usable directly in the energy screen